### PR TITLE
feat: HA-aligned pytest harness and integration tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.test.txt
+      - name: Run pytest
+        run: pytest

--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,0 +1,1 @@
+"""Namespace for custom integrations under this repository."""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,0 +1,3 @@
+# Pins pytest-homeassistant-custom-component to the Home Assistant test harness.
+# Transitive deps include pytest, homeassistant, numpy, etc.
+pytest-homeassistant-custom-component==0.13.324

--- a/tests/components/omlet_smart_coop/__init__.py
+++ b/tests/components/omlet_smart_coop/__init__.py
@@ -1,0 +1,12 @@
+"""Tests for Omlet Smart Coop integration."""
+
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+
+async def init_integration(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Set up the Omlet Smart Coop integration in Home Assistant."""
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/omlet_smart_coop/conftest.py
+++ b/tests/components/omlet_smart_coop/conftest.py
@@ -1,0 +1,119 @@
+"""Fixtures for Omlet Smart Coop tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.setup import async_setup_component
+
+from custom_components.omlet_smart_coop.const import CONF_API_KEY, DOMAIN
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+
+@pytest.fixture
+async def http_stack(hass):
+    """Minimal HTTP + webhook + API for hass_client and /api/webhook tests."""
+    assert await async_setup_component(hass, "http", {"http": {}})
+    assert await async_setup_component(hass, "webhook", {})
+    assert await async_setup_component(hass, "api", {})
+
+
+@pytest.fixture
+def omlet_devices() -> list[dict]:
+    return [
+        {
+            "deviceId": "door-1",
+            "deviceSerial": "SERIAL_DOOR_1",
+            "firmware": "1.0.0",
+            "name": "Coop Door",
+            "deviceType": "Autodoor",
+            "state": {
+                "general": {
+                    "firmwareVersionCurrent": "1.0.0",
+                    "batteryLevel": 75,
+                    "powerSource": "internal",
+                    "uptime": 1234,
+                },
+                "connectivity": {
+                    "wifiStrength": -45,
+                    "ssid": "TestNet",
+                    "connected": True,
+                },
+                "door": {
+                    "state": "closed",
+                    "lastOpenTime": "2026-01-01T08:00:00-05:00",
+                    "lastCloseTime": "2026-01-01T17:00:00-05:00",
+                    "fault": "none",
+                    "lightLevel": 10,
+                },
+                "light": {"state": "off"},
+            },
+            "configuration": {
+                "light": {
+                    "mode": "auto",
+                    "minutesBeforeClose": 5,
+                    "maxOnTime": 3,
+                    "equipped": 1,
+                },
+                "door": {
+                    "openMode": "time",
+                    "openDelay": 0,
+                    "openTime": "08:00",
+                    "closeMode": "time",
+                    "closeDelay": 0,
+                    "closeLightLevel": 6,
+                    "closeTime": "17:00",
+                    "openLightLevel": 15,
+                },
+                "fan": {},
+                "connectivity": {"wifiState": "on"},
+                "general": {"timezone": "America/Detroit"},
+            },
+            "actions": [
+                {
+                    "actionName": "open",
+                    "description": "Open Door",
+                    "actionValue": "open",
+                    "url": "/device/door-1/action/open",
+                },
+                {
+                    "actionName": "close",
+                    "description": "Close Door",
+                    "actionValue": "close",
+                    "url": "/device/door-1/action/close",
+                },
+                {
+                    "actionName": "on",
+                    "description": "Light On",
+                    "actionValue": "on",
+                    "url": "/device/door-1/action/on",
+                },
+                {
+                    "actionName": "off",
+                    "description": "Light Off",
+                    "actionValue": "off",
+                    "url": "/device/door-1/action/off",
+                },
+            ],
+        }
+    ]
+
+
+@pytest.fixture
+def config_entry() -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_API_KEY: "test-api-key"},
+        options={},
+        title="Omlet Smart Coop",
+    )
+
+
+@pytest.fixture
+def mock_fetch_devices(omlet_devices: list[dict]) -> Generator[AsyncMock]:
+    """Mock Omlet API fetch_devices."""
+    with patch(
+        "custom_components.omlet_smart_coop.api_client.OmletApiClient.fetch_devices",
+        new=AsyncMock(return_value=omlet_devices),
+    ) as mock_fetch:
+        yield mock_fetch

--- a/tests/components/omlet_smart_coop/test_config_flow.py
+++ b/tests/components/omlet_smart_coop/test_config_flow.py
@@ -1,0 +1,85 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.data_entry_flow import FlowResultType, InvalidData
+
+from custom_components.omlet_smart_coop.const import (
+    CONF_API_KEY,
+    CONF_DEFAULT_POLLING_INTERVAL,
+    CONF_DISABLE_POLLING,
+    CONF_ENABLE_WEBHOOKS,
+    CONF_POLLING_INTERVAL,
+    CONF_WEBHOOK_TOKEN,
+    DOMAIN,
+)
+
+
+@pytest.mark.asyncio
+async def test_config_flow_valid(hass):
+    with patch(
+        "custom_components.omlet_smart_coop.config_flow.OmletApiClient.is_valid",
+        new=AsyncMock(return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={CONF_API_KEY: "valid-key", CONF_POLLING_INTERVAL: 600},
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_API_KEY] == "valid-key"
+    assert result["data"][CONF_POLLING_INTERVAL] == 600
+
+
+@pytest.mark.asyncio
+async def test_config_flow_invalid_auth(hass):
+    with patch(
+        "custom_components.omlet_smart_coop.config_flow.OmletApiClient.is_valid",
+        new=AsyncMock(return_value=False),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={CONF_API_KEY: "invalid-key"},
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"][CONF_API_KEY] == "invalid_auth"
+
+
+@pytest.mark.asyncio
+async def test_options_flow_validation(hass, config_entry):
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == FlowResultType.FORM
+
+    # Below minimum polling interval is rejected by the options schema (vol.Range).
+    with pytest.raises(InvalidData):
+        await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_POLLING_INTERVAL: 10,
+                CONF_ENABLE_WEBHOOKS: True,
+                CONF_WEBHOOK_TOKEN: "token",
+                CONF_DISABLE_POLLING: False,
+            },
+        )
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == FlowResultType.FORM
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_POLLING_INTERVAL: CONF_DEFAULT_POLLING_INTERVAL,
+            CONF_ENABLE_WEBHOOKS: True,
+            CONF_WEBHOOK_TOKEN: "token",
+            CONF_DISABLE_POLLING: False,
+        },
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_POLLING_INTERVAL] == CONF_DEFAULT_POLLING_INTERVAL

--- a/tests/components/omlet_smart_coop/test_coordinator.py
+++ b/tests/components/omlet_smart_coop/test_coordinator.py
@@ -1,0 +1,30 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.omlet_smart_coop.coordinator import OmletDataCoordinator
+
+
+@pytest.mark.asyncio
+async def test_coordinator_refresh_success(hass, config_entry, mock_fetch_devices):
+    coordinator = OmletDataCoordinator(hass, "test-api-key", config_entry)
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success is True
+    assert "door-1" in coordinator.data
+    assert coordinator.data["door-1"]["deviceId"] == "door-1"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_refresh_invalid_payload(hass, config_entry):
+    with patch(
+        "custom_components.omlet_smart_coop.api_client.OmletApiClient.fetch_devices",
+        new=AsyncMock(return_value={}),
+    ):
+        coordinator = OmletDataCoordinator(hass, "test-api-key", config_entry)
+        await coordinator.async_refresh()
+
+    assert coordinator.last_update_success is False
+    assert isinstance(coordinator.last_exception, UpdateFailed)

--- a/tests/components/omlet_smart_coop/test_diagnostics.py
+++ b/tests/components/omlet_smart_coop/test_diagnostics.py
@@ -1,0 +1,36 @@
+"""Test diagnostics for Omlet Smart Coop integration."""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
+
+from custom_components.omlet_smart_coop.const import CONF_API_KEY, CONF_WEBHOOK_TOKEN, DOMAIN
+from custom_components.omlet_smart_coop.diagnostics import async_get_config_entry_diagnostics
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from . import init_integration
+
+
+async def test_entry_diagnostics_redacts_secrets(
+    hass: HomeAssistant,
+    omlet_devices,
+) -> None:
+    """Ensure diagnostics redact secrets."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_API_KEY: "test-api-key"},
+        options={CONF_WEBHOOK_TOKEN: "secret"},
+        title="Omlet Smart Coop",
+    )
+
+    with patch(
+        "custom_components.omlet_smart_coop.api_client.OmletApiClient.fetch_devices",
+        new=AsyncMock(return_value=omlet_devices),
+    ):
+        await init_integration(hass, entry)
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diagnostics["entry"]["data"][CONF_API_KEY] == REDACTED
+    assert diagnostics["entry"]["options"][CONF_WEBHOOK_TOKEN] == REDACTED

--- a/tests/components/omlet_smart_coop/test_entities.py
+++ b/tests/components/omlet_smart_coop/test_entities.py
@@ -1,0 +1,25 @@
+import pytest
+
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.omlet_smart_coop.const import DOMAIN
+
+from . import init_integration
+
+
+@pytest.mark.asyncio
+async def test_entity_setup_registers_device_and_entities(hass, config_entry, mock_fetch_devices):
+    await init_integration(hass, config_entry)
+
+    ent_reg = er.async_get(hass)
+    cover_entity_id = ent_reg.async_get_entity_id("cover", DOMAIN, "SERIAL_DOOR_1_door")
+    light_entity_id = ent_reg.async_get_entity_id("light", DOMAIN, "SERIAL_DOOR_1_light")
+
+    assert cover_entity_id is not None
+    assert light_entity_id is not None
+
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, "SERIAL_DOOR_1")})
+    assert device is not None
+    assert device.manufacturer == "Omlet"

--- a/tests/components/omlet_smart_coop/test_init.py
+++ b/tests/components/omlet_smart_coop/test_init.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import AsyncMock, patch
 
-import pytest
-
 from aiohttp import ClientError
 
 from homeassistant.config_entries import ConfigEntryState

--- a/tests/components/omlet_smart_coop/test_init.py
+++ b/tests/components/omlet_smart_coop/test_init.py
@@ -1,0 +1,53 @@
+"""Test init of Omlet Smart Coop integration."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aiohttp import ClientError
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from custom_components.omlet_smart_coop.const import DOMAIN
+
+from . import init_integration
+
+
+async def test_async_setup_entry(
+    hass: HomeAssistant,
+    config_entry,
+    mock_fetch_devices,
+) -> None:
+    """Test a successful setup entry."""
+    await init_integration(hass, config_entry)
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_config_not_ready(hass: HomeAssistant, config_entry) -> None:
+    """Test setup retry when the API is unavailable."""
+    with patch(
+        "custom_components.omlet_smart_coop.api_client.OmletApiClient.fetch_devices",
+        new=AsyncMock(side_effect=ClientError("boom")),
+    ):
+        await init_integration(hass, config_entry)
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_unload_entry(
+    hass: HomeAssistant,
+    config_entry,
+    mock_fetch_devices,
+) -> None:
+    """Test successful unload of entry."""
+    await init_integration(hass, config_entry)
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+    assert config_entry.entry_id not in hass.data[DOMAIN]

--- a/tests/components/omlet_smart_coop/test_webhook.py
+++ b/tests/components/omlet_smart_coop/test_webhook.py
@@ -1,0 +1,45 @@
+import pytest
+
+from custom_components.omlet_smart_coop.const import (
+    CONF_API_KEY,
+    CONF_ENABLE_WEBHOOKS,
+    CONF_WEBHOOK_ID,
+    CONF_WEBHOOK_TOKEN,
+    DOMAIN,
+)
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from . import init_integration
+
+
+@pytest.mark.asyncio
+async def test_webhook_requires_token_when_configured(
+    hass, http_stack, hass_client_no_auth, mock_fetch_devices
+):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_API_KEY: "test-api-key"},
+        options={CONF_ENABLE_WEBHOOKS: True, CONF_WEBHOOK_TOKEN: "secret"},
+    )
+    await init_integration(hass, entry)
+
+    entry = hass.config_entries.async_get_entry(entry.entry_id)
+    webhook_id = entry.data.get(CONF_WEBHOOK_ID)
+    assert webhook_id
+
+    client = await hass_client_no_auth()
+
+    resp = await client.post(
+        f"/api/webhook/{webhook_id}",
+        json={"payload": {"deviceId": "door-1"}},
+    )
+    assert resp.status == 401
+    assert (await resp.text()) == "invalid token"
+
+    resp = await client.post(
+        f"/api/webhook/{webhook_id}",
+        json={"payload": {"deviceId": "door-1"}},
+        headers={"X-Omlet-Token": "secret"},
+    )
+    assert resp.status == 200
+    assert (await resp.text()) == "ok"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Pytest configuration for Home Assistant custom component tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Resolve this repo's `custom_components` before Home Assistant's test harness
+# (pytest-homeassistant-custom-component uses its own testing_config tree).
+_ROOT = Path(__file__).resolve().parent.parent
+_root_str = str(_ROOT)
+if _root_str not in sys.path:
+    sys.path.insert(0, _root_str)
+sys.modules.pop("custom_components", None)
+
+import pytest
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations) -> None:
+    """Required by pytest-homeassistant-custom-component (see package README)."""

--- a/tests/test_webhook_helpers.py
+++ b/tests/test_webhook_helpers.py
@@ -1,24 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-import importlib.util
-from pathlib import Path
-import sys
 from types import SimpleNamespace
-import unittest
 
+import pytest
 
-MODULE_PATH = (
-    Path(__file__).resolve().parents[1]
-    / "custom_components"
-    / "omlet_smart_coop"
-    / "webhook_helpers.py"
-)
-SPEC = importlib.util.spec_from_file_location("omlet_webhook_helpers", MODULE_PATH)
-webhook_helpers = importlib.util.module_from_spec(SPEC)
-assert SPEC.loader is not None
-sys.modules[SPEC.name] = webhook_helpers
-SPEC.loader.exec_module(webhook_helpers)
+from custom_components.omlet_smart_coop import webhook_helpers
 
 
 class FakeRequest:
@@ -83,179 +70,168 @@ class FakeHassWithConfig:
         self.config_entries = FakeConfigEntries()
 
 
-class WebhookTokenTests(unittest.TestCase):
-    def test_extracts_authorization_token(self):
-        request = FakeRequest(headers={"Authorization": "Bearer expected"})
+def test_extracts_authorization_token():
+    request = FakeRequest(headers={"Authorization": "Bearer expected"})
+    details = webhook_helpers.get_provided_webhook_token_details(request, {})
+    assert details.token == "expected"
+    assert details.source == "header:Authorization"
 
-        details = webhook_helpers.get_provided_webhook_token_details(request, {})
 
-        self.assertEqual(details.token, "expected")
-        self.assertEqual(details.source, "header:Authorization")
+def test_extracts_supported_header_token():
+    request = FakeRequest(headers={"X-Omlet-Webhook-Token": " expected "})
+    details = webhook_helpers.get_provided_webhook_token_details(request, {})
+    assert details.token == "expected"
+    assert details.source == "header:X-Omlet-Webhook-Token"
 
-    def test_extracts_supported_header_token(self):
-        request = FakeRequest(headers={"X-Omlet-Webhook-Token": " expected "})
 
-        details = webhook_helpers.get_provided_webhook_token_details(request, {})
+def test_extracts_top_level_payload_token():
+    request = FakeRequest()
+    details = webhook_helpers.get_provided_webhook_token_details(
+        request,
+        {"token": "expected"},
+    )
+    assert details.token == "expected"
+    assert details.source == "payload:token"
 
-        self.assertEqual(details.token, "expected")
-        self.assertEqual(details.source, "header:X-Omlet-Webhook-Token")
 
-    def test_extracts_top_level_payload_token(self):
-        request = FakeRequest()
+def test_extracts_nested_payload_token():
+    request = FakeRequest()
+    details = webhook_helpers.get_provided_webhook_token_details(
+        request,
+        {"payload": {"webhookToken": "expected"}},
+    )
+    assert details.token == "expected"
+    assert details.source == "payload.payload:webhookToken"
 
-        details = webhook_helpers.get_provided_webhook_token_details(
-            request,
-            {"token": "expected"},
+
+def test_extracts_query_token():
+    request = FakeRequest(query={"token": "expected"})
+    details = webhook_helpers.get_provided_webhook_token_details(request, {})
+    assert details.token == "expected"
+    assert details.source == "query:token"
+
+
+@pytest.mark.asyncio
+async def test_official_payload_without_configured_token_refreshes():
+    entry = SimpleNamespace(options={})
+    coordinator = FakeCoordinator()
+    hass = FakeHass()
+    handler = webhook_helpers.create_omlet_webhook_handler(
+        entry,
+        coordinator,
+        response_factory=FakeResponse,
+        logger=NullLogger(),
+    )
+    response = await handler(
+        hass,
+        "0123456789abcdef",
+        FakeRequest(
+            {
+                "deviceId": "1234567",
+                "parameterName": "Door Open State",
+                "oldValue": "closed",
+                "newValue": "open",
+            }
+        ),
+    )
+    await asyncio.gather(*hass.tasks)
+    assert response.status == 200
+    assert coordinator.refreshes == 1
+
+
+@pytest.mark.asyncio
+async def test_configured_token_mismatch_rejects_without_refresh():
+    entry = SimpleNamespace(options={"webhook_token": "expected"})
+    coordinator = FakeCoordinator()
+    hass = FakeHass()
+    handler = webhook_helpers.create_omlet_webhook_handler(
+        entry,
+        coordinator,
+        response_factory=FakeResponse,
+        logger=NullLogger(),
+    )
+    response = await handler(
+        hass,
+        "0123456789abcdef",
+        FakeRequest({"token": "wrong"}),
+    )
+    assert response.status == 401
+    assert coordinator.refreshes == 0
+    assert hass.tasks == []
+
+
+@pytest.mark.asyncio
+async def test_configured_token_match_refreshes():
+    entry = SimpleNamespace(options={"webhook_token": "expected"})
+    coordinator = FakeCoordinator()
+    hass = FakeHass()
+    handler = webhook_helpers.create_omlet_webhook_handler(
+        entry,
+        coordinator,
+        response_factory=FakeResponse,
+        logger=NullLogger(),
+    )
+    response = await handler(
+        hass,
+        "0123456789abcdef",
+        FakeRequest({"token": "expected"}),
+    )
+    await asyncio.gather(*hass.tasks)
+    assert response.status == 200
+    assert coordinator.refreshes == 1
+
+
+@pytest.mark.asyncio
+async def test_non_json_payload_is_controlled_response():
+    entry = SimpleNamespace(options={})
+    coordinator = FakeCoordinator()
+    hass = FakeHass()
+    handler = webhook_helpers.create_omlet_webhook_handler(
+        entry,
+        coordinator,
+        response_factory=FakeResponse,
+        logger=NullLogger(),
+    )
+    response = await handler(
+        hass,
+        "0123456789abcdef",
+        FakeRequest(json_error=ValueError("not json")),
+    )
+    await asyncio.gather(*hass.tasks)
+    assert response.status == 200
+    assert coordinator.refreshes == 1
+
+
+def test_generates_stable_random_webhook_id():
+    hass = FakeHassWithConfig()
+    entry = SimpleNamespace(data={})
+    webhook_id = webhook_helpers.ensure_omlet_webhook_id(hass, entry)
+    assert len(webhook_id) == 32
+    assert entry.data["webhook_id"] == webhook_id
+    assert hass.config_entries.updates[-1]["webhook_id"] == webhook_id
+
+
+def test_reuses_existing_random_webhook_id():
+    hass = FakeHassWithConfig()
+    entry = SimpleNamespace(data={"webhook_id": "existing"})
+    webhook_id = webhook_helpers.ensure_omlet_webhook_id(hass, entry)
+    assert webhook_id == "existing"
+    assert hass.config_entries.updates == []
+
+
+def test_warns_for_non_public_urls():
+    assert webhook_helpers.describe_webhook_url("/api/webhook/id") is not None
+    assert (
+        webhook_helpers.describe_webhook_url(
+            "https://homeassistant.local/api/webhook/id"
         )
-
-        self.assertEqual(details.token, "expected")
-        self.assertEqual(details.source, "payload:token")
-
-    def test_extracts_nested_payload_token(self):
-        request = FakeRequest()
-
-        details = webhook_helpers.get_provided_webhook_token_details(
-            request,
-            {"payload": {"webhookToken": "expected"}},
-        )
-
-        self.assertEqual(details.token, "expected")
-        self.assertEqual(details.source, "payload.payload:webhookToken")
-
-    def test_extracts_query_token(self):
-        request = FakeRequest(query={"token": "expected"})
-
-        details = webhook_helpers.get_provided_webhook_token_details(request, {})
-
-        self.assertEqual(details.token, "expected")
-        self.assertEqual(details.source, "query:token")
-
-
-class WebhookHandlerTests(unittest.IsolatedAsyncioTestCase):
-    async def test_official_payload_without_configured_token_refreshes(self):
-        entry = SimpleNamespace(options={})
-        coordinator = FakeCoordinator()
-        hass = FakeHass()
-        handler = webhook_helpers.create_omlet_webhook_handler(
-            entry,
-            coordinator,
-            response_factory=FakeResponse,
-            logger=NullLogger(),
-        )
-
-        response = await handler(
-            hass,
-            "0123456789abcdef",
-            FakeRequest(
-                {
-                    "deviceId": "1234567",
-                    "parameterName": "Door Open State",
-                    "oldValue": "closed",
-                    "newValue": "open",
-                }
-            ),
-        )
-        await asyncio.gather(*hass.tasks)
-
-        self.assertEqual(response.status, 200)
-        self.assertEqual(coordinator.refreshes, 1)
-
-    async def test_configured_token_mismatch_rejects_without_refresh(self):
-        entry = SimpleNamespace(options={"webhook_token": "expected"})
-        coordinator = FakeCoordinator()
-        hass = FakeHass()
-        handler = webhook_helpers.create_omlet_webhook_handler(
-            entry,
-            coordinator,
-            response_factory=FakeResponse,
-            logger=NullLogger(),
-        )
-
-        response = await handler(
-            hass,
-            "0123456789abcdef",
-            FakeRequest({"token": "wrong"}),
-        )
-
-        self.assertEqual(response.status, 401)
-        self.assertEqual(coordinator.refreshes, 0)
-        self.assertEqual(hass.tasks, [])
-
-    async def test_configured_token_match_refreshes(self):
-        entry = SimpleNamespace(options={"webhook_token": "expected"})
-        coordinator = FakeCoordinator()
-        hass = FakeHass()
-        handler = webhook_helpers.create_omlet_webhook_handler(
-            entry,
-            coordinator,
-            response_factory=FakeResponse,
-            logger=NullLogger(),
-        )
-
-        response = await handler(
-            hass,
-            "0123456789abcdef",
-            FakeRequest({"token": "expected"}),
-        )
-        await asyncio.gather(*hass.tasks)
-
-        self.assertEqual(response.status, 200)
-        self.assertEqual(coordinator.refreshes, 1)
-
-    async def test_non_json_payload_is_controlled_response(self):
-        entry = SimpleNamespace(options={})
-        coordinator = FakeCoordinator()
-        hass = FakeHass()
-        handler = webhook_helpers.create_omlet_webhook_handler(
-            entry,
-            coordinator,
-            response_factory=FakeResponse,
-            logger=NullLogger(),
-        )
-
-        response = await handler(
-            hass,
-            "0123456789abcdef",
-            FakeRequest(json_error=ValueError("not json")),
-        )
-        await asyncio.gather(*hass.tasks)
-
-        self.assertEqual(response.status, 200)
-        self.assertEqual(coordinator.refreshes, 1)
-
-
-class WebhookIdAndUrlTests(unittest.TestCase):
-    def test_generates_stable_random_webhook_id(self):
-        hass = FakeHassWithConfig()
-        entry = SimpleNamespace(data={})
-
-        webhook_id = webhook_helpers.ensure_omlet_webhook_id(hass, entry)
-
-        self.assertEqual(len(webhook_id), 32)
-        self.assertEqual(entry.data["webhook_id"], webhook_id)
-        self.assertEqual(hass.config_entries.updates[-1]["webhook_id"], webhook_id)
-
-    def test_reuses_existing_random_webhook_id(self):
-        hass = FakeHassWithConfig()
-        entry = SimpleNamespace(data={"webhook_id": "existing"})
-
-        webhook_id = webhook_helpers.ensure_omlet_webhook_id(hass, entry)
-
-        self.assertEqual(webhook_id, "existing")
-        self.assertEqual(hass.config_entries.updates, [])
-
-    def test_warns_for_non_public_urls(self):
-        self.assertIsNotNone(webhook_helpers.describe_webhook_url("/api/webhook/id"))
-        self.assertIsNotNone(
-            webhook_helpers.describe_webhook_url("https://homeassistant.local/api/webhook/id")
-        )
-        self.assertIsNotNone(
-            webhook_helpers.describe_webhook_url("http://192.168.1.10/api/webhook/id")
-        )
-        self.assertIsNone(
-            webhook_helpers.describe_webhook_url("https://example.com/api/webhook/id")
-        )
-
-
-if __name__ == "__main__":
-    unittest.main()
+        is not None
+    )
+    assert (
+        webhook_helpers.describe_webhook_url("http://192.168.1.10/api/webhook/id")
+        is not None
+    )
+    assert (
+        webhook_helpers.describe_webhook_url("https://example.com/api/webhook/id")
+        is None
+    )


### PR DESCRIPTION
Adds the salvaged alignment work on top of current main in a single commit.

**Includes**
- `pytest-homeassistant-custom-component` + `requirements.test.txt`, `pytest.ini`
- GitHub Actions workflow: pytest on PR and push to `main` (Python 3.14)
- Tests under `tests/components/omlet_smart_coop/` with fixtures
- Root `tests/conftest.py`: repo `custom_components` on `sys.path`, `enable_custom_integrations`
- `custom_components/__init__.py` for loader discovery
- Webhook/unit tests updated for current integration behavior

Replaces the obsolete `test/ha-alignment-tests` branch (to be deleted).

Made with [Cursor](https://cursor.com)